### PR TITLE
change tests to use common protocol in preparation for dm5

### DIFF
--- a/nionswift_plugin/DM_IO/test/dm3parser_test.py
+++ b/nionswift_plugin/DM_IO/test/dm3parser_test.py
@@ -15,7 +15,6 @@ import typing
 
 import h5py
 import numpy
-import numpy.typing
 
 from nion.io.DM_IO import parse_dm3
 from nion.io.DM_IO import dm3_image_utils
@@ -36,7 +35,7 @@ def is_equal(r: typing.Any, data: typing.Any) -> bool:
         return bool(r == data)
 
 
-class TestDM3ImportExportClass(unittest.TestCase):
+class TestParseDM3(unittest.TestCase):
 
     def check_write_then_read_matches(self, data: typing.Any, write_func: typing.Callable[..., typing.Any], read_func: typing.Callable[..., typing.Any], _assert: bool = True) -> typing.Any:
         # we confirm that reading a written element returns the same value
@@ -118,6 +117,35 @@ class TestDM3ImportExportClass(unittest.TestCase):
         self.assertTrue(is_equal(ret["Data"], im_tag["Data"]))
         self.assertEqual(im_tag["Dimensions"], ret["Dimensions"])
 
+
+class DMHandlerProtocol(typing.Protocol):
+    @property
+    def version(self) -> int:
+        ...
+
+    def load_image(self, b_file: typing.BinaryIO) -> DataAndMetadata.DataAndMetadata:
+        ...
+
+    def save_image(self, data_and_metadata: DataAndMetadata.DataAndMetadata, file: typing.BinaryIO,
+                   file_version: int) -> None:
+        ...
+
+
+class DM34Handler:
+    def __init__(self, version: int) -> None:
+        self.version:int = version
+
+    def load_image(self, b_file: typing.BinaryIO) -> DataAndMetadata.DataAndMetadata:
+        return dm3_image_utils.load_image(b_file)
+
+    def save_image(self, data_and_metadata: DataAndMetadata.DataAndMetadata, file: typing.BinaryIO,
+                   file_version: int) -> None:
+        return dm3_image_utils.save_image(data_and_metadata, file, file_version)
+
+
+class TestDMHandlers(unittest.TestCase):
+    dm_handlers: typing.Sequence[DMHandlerProtocol] = [DM34Handler(3), DM34Handler(4)]
+
     def test_data_write_read_round_trip(self) -> None:
         def db_make_directory_if_needed(directory_path: str) -> None:
             if os.path.exists(directory_path):
@@ -160,7 +188,7 @@ class TestDM3ImportExportClass(unittest.TestCase):
             ((6, 5, 4, 2), DataAndMetadata.DataDescriptor(False, 2, 2)),   # 2d collection of images. not possible?
             ((6, 8, 10), DataAndMetadata.DataDescriptor(True, 0, 2)),   # sequence of images
         )
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             for array_type in array_types:
                 for dtype in dtypes:
                     for shape, data_descriptor_in in shape_data_descriptors:
@@ -177,16 +205,16 @@ class TestDM3ImportExportClass(unittest.TestCase):
                                 if signal_type:
                                     metadata_in.setdefault("hardware_source", dict())["signal_type"] = signal_type
                                 xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-                                dm3_image_utils.save_image(xdata_in, s, version)
+                                handler.save_image(xdata_in, s, handler.version)
                                 s.seek(0)
-                                xdata = dm3_image_utils.load_image(s)
+                                xdata = handler.load_image(s)
                                 self.assertTrue(numpy.array_equal(data_in, xdata.data))
                                 self.assertEqual(data_descriptor_in, xdata.data_descriptor)
                                 self.assertEqual(tuple(dimensional_calibrations_in), tuple(xdata.dimensional_calibrations))
                                 self.assertEqual(intensity_calibration_in, xdata.intensity_calibration)
 
     def test_rgb_data_write_read_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = (numpy.random.randn(6, 4, 3) * 255).astype(numpy.uint8)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -194,14 +222,14 @@ class TestDM3ImportExportClass(unittest.TestCase):
             intensity_calibration_in = Calibration.Calibration(4, 5, "six")
             metadata_in: dict[str, typing.Any] = {"abc": None, "": "", "one": [], "two": {}, "three": [1, None, 2]}
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             self.assertTrue(numpy.array_equal(data_in, xdata.data))
             self.assertEqual(data_descriptor_in, xdata.data_descriptor)
 
     def test_calibrations_write_read_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((6, 4), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -209,14 +237,14 @@ class TestDM3ImportExportClass(unittest.TestCase):
             intensity_calibration_in = Calibration.Calibration(4.4, 5.5, "six")
             metadata_in = dict[str, typing.Any]()
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             self.assertEqual(tuple(dimensional_calibrations_in), tuple(xdata.dimensional_calibrations))
             self.assertEqual(intensity_calibration_in, xdata.intensity_calibration)
 
     def test_data_timestamp_write_read_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((6, 4), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -227,15 +255,15 @@ class TestDM3ImportExportClass(unittest.TestCase):
             timezone_in = "America/Los_Angeles"
             timezone_offset_in = "-0700"
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in, timestamp=timestamp_in, timezone=timezone_in, timezone_offset=timezone_offset_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             self.assertEqual(timestamp_in, xdata.timestamp)
             self.assertEqual(timezone_in, xdata.timezone)
             self.assertEqual(timezone_offset_in, xdata.timezone_offset)
 
     def test_metadata_write_read_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((6, 4), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -255,13 +283,13 @@ class TestDM3ImportExportClass(unittest.TestCase):
                 }
             }
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             self.assertEqual(metadata_in, xdata.metadata)
 
     def test_metadata_difficult_types_write_read_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((6, 4), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -269,14 +297,14 @@ class TestDM3ImportExportClass(unittest.TestCase):
             intensity_calibration_in = Calibration.Calibration(4, 5, "six")
             metadata_in: dict[str, typing.Any] = {"abc": None, "": "", "one": [], "two": {}, "three": [1, None, 2]}
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             metadata_expected = {"one": [], "two": {}, "three": [1, 2]}
             self.assertEqual(metadata_expected, xdata.metadata)
 
     def test_metadata_export_large_integer(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((6, 4), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 2)
@@ -284,14 +312,14 @@ class TestDM3ImportExportClass(unittest.TestCase):
             intensity_calibration_in = Calibration.Calibration(4, 5, "six")
             metadata_in: dict[str, typing.Any] = {"abc": 999999999999}
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             metadata_expected = {"abc": 999999999999}
             self.assertEqual(metadata_expected, xdata.metadata)
 
     def test_signal_type_round_trip(self) -> None:
-        for version in (3, 4):
+        for handler in self.dm_handlers:
             s = io.BytesIO()
             data_in = numpy.ones((12,), numpy.float32)
             data_descriptor_in = DataAndMetadata.DataDescriptor(False, 0, 1)
@@ -299,9 +327,9 @@ class TestDM3ImportExportClass(unittest.TestCase):
             intensity_calibration_in = Calibration.Calibration(4, 5, "e")
             metadata_in = {"hardware_source": {"signal_type": "EELS"}}
             xdata_in = DataAndMetadata.new_data_and_metadata(data_in, data_descriptor=data_descriptor_in, dimensional_calibrations=dimensional_calibrations_in, intensity_calibration=intensity_calibration_in, metadata=metadata_in)
-            dm3_image_utils.save_image(xdata_in, s, version)
+            handler.save_image(xdata_in, s, handler.version)
             s.seek(0)
-            xdata = dm3_image_utils.load_image(s)
+            xdata = handler.load_image(s)
             metadata_expected = {'hardware_source': {'signal_type': 'EELS'}, 'Meta Data': {'Format': 'Spectrum', 'Signal': 'EELS'}}
             self.assertEqual(metadata_expected, xdata.metadata)
 
@@ -315,26 +343,26 @@ class TestDM3ImportExportClass(unittest.TestCase):
             ((4, 3, 2), DataAndMetadata.DataDescriptor(False, 1, 2)),   # 1d collection of images
             ((3, 4, 5), DataAndMetadata.DataDescriptor(True, 0, 2)),    # sequence of images
         )
-        for (shape, data_descriptor), version in itertools.product(shape_data_descriptors, (3, 4)):
+        for handler, (shape, data_descriptor) in itertools.product(self.dm_handlers, shape_data_descriptors):
             dimensional_calibrations = list()
             for index, dimension in enumerate(shape):
                 dimensional_calibrations.append(Calibration.Calibration(1.0 + 0.1 * index, 2.0 + 0.2 * index, "µ" + "n" * index))
             intensity_calibration = Calibration.Calibration(4, 5, "six")
             data = numpy.arange(numpy.prod(shape), dtype=numpy.float32).reshape(shape)
 
-            name = f"ref_{'T' if data_descriptor.is_sequence else 'F'}_{data_descriptor.collection_dimension_count}_{data_descriptor.datum_dimension_count}.dm{version}"
+            name = f"ref_{'T' if data_descriptor.is_sequence else 'F'}_{data_descriptor.collection_dimension_count}_{data_descriptor.datum_dimension_count}.dm{handler.version}"
 
             # import pathlib
             # xdata = DataAndMetadata.new_data_and_metadata(data, dimensional_calibrations=dimensional_calibrations, intensity_calibration=intensity_calibration, data_descriptor=data_descriptor)
             # file_path = pathlib.Path(__file__).parent / "resources" / name
             # with file_path.open('wb') as f:
-            #     dm3_image_utils.save_image(xdata, f, version)
+            #     handler.save_image(xdata, f, handler.version)
 
             try:
                 _data = pkgutil.get_data(__name__, f"resources/{name}")
                 assert _data is not None
                 s = io.BytesIO(_data)
-                xdata = dm3_image_utils.load_image(s)
+                xdata = handler.load_image(s)
                 self.assertAlmostEqual(intensity_calibration.scale, xdata.intensity_calibration.scale, 6)
                 self.assertAlmostEqual(intensity_calibration.offset, xdata.intensity_calibration.offset, 6)
                 self.assertEqual(intensity_calibration.units, xdata.intensity_calibration.units)
@@ -355,7 +383,7 @@ class TestDM3ImportExportClass(unittest.TestCase):
             xdata = dm3_image_utils.load_image(f)
         # file_path = "/path/to/test-new.dm3"
         # with open(file_path, "wb") as f:
-        #     dm3_image_utils.save_image(xdata, f, 3)
+        #     handler.save_image(xdata, f, 3)
 
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
In preparation for dm5 using the same unittests as dm4 this splits the test class in two. The first is the parser tests (TestParseDM3), that test functions in parse_dm3.py. The second is TestDMHandlers which tests the save_image and load_image functionality of dm3/4 and will test the dm5 versions of said functions. The changes to the tests in that class are to use the list of dm handlers instead of the list of versions. The DMHandlerProtocol is added as a shared protocol between the dm3/4 load/save image and the upcoming dm5 versions of the functions.
The tests are left as close as possible to unchanged, there are improvements that could be made such as using subtest and removing commented out code but that can be a separate PR.